### PR TITLE
BGK-61

### DIFF
--- a/BearGoodbyeKolkhoz.API/Infrastructure/ErrorHandlerMiddleware.cs
+++ b/BearGoodbyeKolkhoz.API/Infrastructure/ErrorHandlerMiddleware.cs
@@ -43,7 +43,7 @@ namespace BearGoodbyeKolkhozProject.API.Infrastructure
             }
             catch (NotFoundException error)
             {
-                await ConstructResponse(context, HttpStatusCode.Forbidden, error.Message);
+                await ConstructResponse(context, HttpStatusCode.BadRequest, error.Message);
             }
             catch (NoRoleException error)
             {


### PR DESCRIPTION
Изменил логику **NotFoundException** в классе ErrorHandlerMiddleware.

Она выплевывала ошибки в swagger 403 и была прикручена к логике когда не верно указывались id, имена и тд со стороны фронта.
Сейчас выдает 400.